### PR TITLE
Simplify call kafka producer

### DIFF
--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -36,11 +36,9 @@ func Bootstrap(config *BootstrapConfig) {
 	var contactProducer *messaging.ContactProducer
 	var addressProducer *messaging.AddressProducer
 
-	if config.Producer != nil {
-		userProducer = messaging.NewUserProducer(config.Producer, config.Log)
-		contactProducer = messaging.NewContactProducer(config.Producer, config.Log)
-		addressProducer = messaging.NewAddressProducer(config.Producer, config.Log)
-	}
+	userProducer = messaging.NewUserProducer(config.Producer, config.Log)
+	contactProducer = messaging.NewContactProducer(config.Producer, config.Log)
+	addressProducer = messaging.NewAddressProducer(config.Producer, config.Log)
 
 	// setup use cases
 	userUseCase := usecase.NewUserUseCase(config.DB, config.Log, config.Validate, userRepository, userProducer)

--- a/internal/gateway/messaging/producer.go
+++ b/internal/gateway/messaging/producer.go
@@ -19,6 +19,11 @@ func (p *Producer[T]) GetTopic() *string {
 }
 
 func (p *Producer[T]) Send(event T) error {
+	if p.Producer == nil {
+		p.Log.Warn("Kafka producer is disabled")
+		return nil
+	}
+
 	value, err := json.Marshal(event)
 	if err != nil {
 		p.Log.WithError(err).Error("failed to marshal event")

--- a/internal/usecase/address_usecase.go
+++ b/internal/usecase/address_usecase.go
@@ -123,15 +123,10 @@ func (c *AddressUseCase) Update(ctx context.Context, request *model.UpdateAddres
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.AddressProducer != nil {
-		event := converter.AddressToEvent(address)
-		if err := c.AddressProducer.Send(event); err != nil {
-			c.Log.WithError(err).Error("failed to publish address updated event")
-			return nil, fiber.ErrInternalServerError
-		}
-		c.Log.Info("Published address updated event")
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping address updated event")
+	event := converter.AddressToEvent(address)
+	if err := c.AddressProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("failed to publish address updated event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.AddressToResponse(address), nil

--- a/internal/usecase/contact_usecase.go
+++ b/internal/usecase/contact_usecase.go
@@ -62,15 +62,10 @@ func (c *ContactUseCase) Create(ctx context.Context, request *model.CreateContac
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.ContactProducer != nil {
-		event := converter.ContactToEvent(contact)
-		if err := c.ContactProducer.Send(event); err != nil {
-			c.Log.WithError(err).Error("error publishing contact created event")
-			return nil, fiber.ErrInternalServerError
-		}
-		c.Log.Info("Published contact created event")
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping contact created event")
+	event := converter.ContactToEvent(contact)
+	if err := c.ContactProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("error publishing contact created event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.ContactToResponse(contact), nil
@@ -106,15 +101,10 @@ func (c *ContactUseCase) Update(ctx context.Context, request *model.UpdateContac
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.ContactProducer != nil {
-		event := converter.ContactToEvent(contact)
-		if err := c.ContactProducer.Send(event); err != nil {
-			c.Log.WithError(err).Error("error publishing contact updated event")
-			return nil, fiber.ErrInternalServerError
-		}
-		c.Log.Info("Published contact updated event")
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping contact updated event")
+	event := converter.ContactToEvent(contact)
+	if err := c.ContactProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("error publishing contact updated event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.ContactToResponse(contact), nil

--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -102,15 +102,10 @@ func (c *UserUseCase) Create(ctx context.Context, request *model.RegisterUserReq
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.UserProducer != nil {
-		event := converter.UserToEvent(user)
-		c.Log.Info("Publishing user created event")
-		if err = c.UserProducer.Send(event); err != nil {
-			c.Log.Warnf("Failed publish user created event : %+v", err)
-			return nil, fiber.ErrInternalServerError
-		}
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping user created event")
+	event := converter.UserToEvent(user)
+	if err = c.UserProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("failed to publish user created event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.UserToResponse(user), nil
@@ -147,15 +142,10 @@ func (c *UserUseCase) Login(ctx context.Context, request *model.LoginUserRequest
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.UserProducer != nil {
-		event := converter.UserToEvent(user)
-		c.Log.Info("Publishing user login event")
-		if err := c.UserProducer.Send(event); err != nil {
-			c.Log.Warnf("Failed publish user login event : %+v", err)
-			return nil, fiber.ErrInternalServerError
-		}
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping user login event")
+	event := converter.UserToEvent(user)
+	if err := c.UserProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("Failed publish user login event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.UserToTokenResponse(user), nil
@@ -211,15 +201,10 @@ func (c *UserUseCase) Logout(ctx context.Context, request *model.LogoutUserReque
 		return false, fiber.ErrInternalServerError
 	}
 
-	if c.UserProducer != nil {
-		event := converter.UserToEvent(user)
-		c.Log.Info("Publishing user logout event")
-		if err := c.UserProducer.Send(event); err != nil {
-			c.Log.Warnf("Failed publish user logout event : %+v", err)
-			return false, fiber.ErrInternalServerError
-		}
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping user logout event")
+	event := converter.UserToEvent(user)
+	if err := c.UserProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("Failed publish user logout event")
+		return false, fiber.ErrInternalServerError
 	}
 
 	return true, nil
@@ -263,15 +248,10 @@ func (c *UserUseCase) Update(ctx context.Context, request *model.UpdateUserReque
 		return nil, fiber.ErrInternalServerError
 	}
 
-	if c.UserProducer != nil {
-		event := converter.UserToEvent(user)
-		c.Log.Info("Publishing user updated event")
-		if err := c.UserProducer.Send(event); err != nil {
-			c.Log.Warnf("Failed publish user updated event : %+v", err)
-			return nil, fiber.ErrInternalServerError
-		}
-	} else {
-		c.Log.Info("Kafka producer is disabled, skipping user updated event")
+	event := converter.UserToEvent(user)
+	if err := c.UserProducer.Send(event); err != nil {
+		c.Log.WithError(err).Error("Failed publish user updated event")
+		return nil, fiber.ErrInternalServerError
 	}
 
 	return converter.UserToResponse(user), nil


### PR DESCRIPTION
Simplify call kafka producer.

from

```go
	if c.AddressProducer != nil {
		event := converter.AddressToEvent(address)
		if err := c.AddressProducer.Send(event); err != nil {
			c.Log.WithError(err).Error("failed to publish address updated event")
			return nil, fiber.ErrInternalServerError
		}
		c.Log.Info("Published address updated event")
	} else {
		c.Log.Info("Kafka producer is disabled, skipping address updated event")
	}
```

to

```go
	event := converter.AddressToEvent(address)
	if err := c.AddressProducer.Send(event); err != nil {
		c.Log.WithError(err).Error("failed to publish address updated event")
		return nil, fiber.ErrInternalServerError
	}
```